### PR TITLE
feat(overflow): propose new name for the app button

### DIFF
--- a/front/src/app/components/mainMenu.vue
+++ b/front/src/app/components/mainMenu.vue
@@ -38,7 +38,7 @@
         class="btn btn-secondary btn-lg block m-1"
         v-on:click="navToOverf"
       >
-        Overflow
+        Live rooms attendances
       </button>
     </div>
     <div>


### PR DESCRIPTION
When using the Floxx app this year. The `overflow` keyword was less significant and could be confusing. 

To see in real time the affluence in each rooms, I propose to change it's name to `Live rooms attendances`, WDYT?
